### PR TITLE
Missing closing paren and incorrect dsknum

### DIFF
--- a/fflex.c
+++ b/fflex.c
@@ -27,6 +27,8 @@
 #include <time.h>
 #include <ctype.h>
 
+//#include "dsk.h"
+
 #define VERSION "1.1 (2024-06-30)"
 
 void usage( char *cmd) {
@@ -172,7 +174,7 @@ int main(int argc, char *argv[])
 		volname[i++] = 0;
 
 // Is Volume number OK ?	
-	if (disknum  < 0 || dsknum > 0xFFFF) {
+	if (dsknum  < 0 || dsknum > 0xFFFF) {
 		printf( "Disk Volume number (%d) must be positive and less than 65536\n", dsknum);
 		usage( *argv);
 	}
@@ -224,6 +226,7 @@ int main(int argc, char *argv[])
 			if (ft < 6 || ft > nbsec) {
 				printf( "Track 0 size must > 6 and less than number of sectors (%n)\n", nbsec);
 				usage( *argv);
+                        }
 		}
 	}
 

--- a/fflex.c
+++ b/fflex.c
@@ -27,9 +27,7 @@
 #include <time.h>
 #include <ctype.h>
 
-//#include "dsk.h"
-
-#define VERSION "1.1 (2024-06-30)"
+#define VERSION "1.1 (2024-07-24)"
 
 void usage( char *cmd) {
 	printf( "Usage : %s [options...] <filename>\n", cmd);


### PR DESCRIPTION
2 changes
line 229 was missing the closing paren.
line 177 dsknum was spelled disknum